### PR TITLE
Use the base folder of the package instead of the working directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function reporter(context, options = {}) {
 }
 
 function getTerms(defaultTerms, terms) {
-	const defaults = defaultTerms ? loadJson(path.resolve(__dirname, './terms.json')) : [];
+	const defaults = defaultTerms ? loadJson(path.resolve(__dirname, 'terms.json')) : [];
 	const extras = typeof terms === 'string' ? loadJson(terms) : terms;
 	return defaults.concat(extras);
 }

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function reporter(context, options = {}) {
 }
 
 function getTerms(defaultTerms, terms) {
-	const defaults = defaultTerms ? loadJson('./terms.json') : [];
+	const defaults = defaultTerms ? loadJson(path.resolve(__dirname, './terms.json')) : [];
 	const extras = typeof terms === 'string' ? loadJson(terms) : terms;
 	return defaults.concat(extras);
 }


### PR DESCRIPTION
By default, `loadJson('./terms.json')` loads a file named terms.json in the working directory. You want the base folder of the package, which is `__dirname`.