### PR TITLE
Switch precedence of rules. User rules have higher priority than default ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function getTerms(defaultTerms, terms, exclude) {
 		? loadJson(path.resolve(__dirname, 'terms.json'))
 		: [];
 	const extras = typeof terms === 'string' ? loadJson(terms) : terms;
-
+	// Order matters, the first term to match is used. We prioritize user 'extras' before defaults
 	const listTerms = [...(Array.isArray(extras) ? extras : []), ...defaults];
 
 	// Filter on all terms

--- a/index.js
+++ b/index.js
@@ -90,12 +90,13 @@ function getTerms(defaultTerms, terms, exclude) {
 		? loadJson(path.resolve(__dirname, 'terms.json'))
 		: [];
 	const extras = typeof terms === 'string' ? loadJson(terms) : terms;
-	const listTerms = defaults.concat(extras);
 
+	const listTerms = [...(Array.isArray(extras) ? extras : []), ...defaults];
+
+	// Filter on all terms
 	if (Array.isArray(exclude)) {
-		return listTerms.filter(term => exclude.indexOf(term) === -1);
+		return listTerms.filter(term => !exclude.includes(term));
 	}
-
 	return listTerms;
 }
 

--- a/test.js
+++ b/test.js
@@ -308,3 +308,39 @@ tester.run('textlint-rule-terminology', rule, {
 		},
 	],
 });
+
+tester.run(
+	'textlint-rule-terminology',
+	{
+		rules: [
+			{
+				ruleId: 'terminology',
+				rule,
+				options: {
+					defaultTerms: true,
+					terms: ['wordpress'],
+				},
+			},
+		],
+	},
+	{
+		valid: [
+			{
+				text: 'This wordpress word is OK',
+			},
+		],
+		invalid: [
+			{
+				// Replace default
+				text: 'My WordPress is good too',
+				output: 'My wordpress is good too',
+				errors: [
+					{
+						message:
+							'Incorrect usage of the term: “WordPress”, use “wordpress” instead',
+					},
+				],
+			},
+		],
+	}
+);


### PR DESCRIPTION
The user defined terms should take precedence before the default terms. This requires switching the order in which the terms are joined.

An integration test was added, to test if this behaviour works: 
- A user defined term is marked as correct instead of the default one
- The auto-fixer uses user terms first, before falling back to default terms