### PR TITLE
Remove Node from terms.jsonrc

### DIFF
--- a/terms.jsonc
+++ b/terms.jsonc
@@ -39,7 +39,7 @@
   "YouTube",
   ["Common[ .]js", "CommonJS"],
   ["JSDocs?", "JSDoc"],
-	["Node[ .]js", "Node.js"],
+  ["Node[ .]js", "Node.js"],
   ["React[ .]js", "React"],
   ["SauceLabs", "Sauce Labs"],
   ["StackOverflow", "Stack Overflow"],

--- a/terms.jsonc
+++ b/terms.jsonc
@@ -39,7 +39,6 @@
   "YouTube",
   ["Common[ .]js", "CommonJS"],
   ["JSDocs?", "JSDoc"],
-  ["Node(?:js)?", "Node.js"],
   ["React[ .]js", "React"],
   ["SauceLabs", "Sauce Labs"],
   ["StackOverflow", "Stack Overflow"],

--- a/terms.jsonc
+++ b/terms.jsonc
@@ -39,6 +39,7 @@
   "YouTube",
   ["Common[ .]js", "CommonJS"],
   ["JSDocs?", "JSDoc"],
+	["Node[ .]js", "Node.js"],
   ["React[ .]js", "React"],
   ["SauceLabs", "Sauce Labs"],
   ["StackOverflow", "Stack Overflow"],

--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ describe('getTerms', () => {
 	});
 
 	it('should remove the excluded terms (defined as Array)', () => {
-		const result = getTerms(true, [], ['Node(?:js)?']);
+		const result = getTerms(true, [], ['Node[ .]js?']);
 		expect(result).toBeTruthy();
 		expect(
 			result.some(term => Array.isArray(term) && term[1] === 'Node.js')

--- a/test.js
+++ b/test.js
@@ -51,7 +51,7 @@ describe('getTerms', () => {
 	});
 
 	it('should remove the excluded terms (defined as Array)', () => {
-		const result = getTerms(true, [], ['Node[ .]js?']);
+		const result = getTerms(true, [], ['Node[ .]js']);
 		expect(result).toBeTruthy();
 		expect(
 			result.some(term => Array.isArray(term) && term[1] === 'Node.js')


### PR DESCRIPTION
Node word is used widely in tons of different contexts, doesn't make much sense to infer that it is related with Node.js
Examples:
- Node as part of a graph
- Node as machine part of a cluster