### PR TITLE
Add PlayStation to brand terms

### DIFF
--- a/terms.jsonc
+++ b/terms.jsonc
@@ -27,6 +27,7 @@
   "OpenType",
   "PayPal",
   "PhpStorm",
+	"PlayStation",
   "RubyMine",
   "Sass",
   "SemVer",


### PR DESCRIPTION
It is common to see PlayStation written incorrectly as 'Playstation'. I suggest adding the correct capitalization to `terms.jsonc`