### PR TITLE
Fix word detection at end of line

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -112,4 +112,3 @@ This software has been developed with lots of coffee, buy me one more cup to kee
 [Artem Sapegin](https://sapegin.me) and [contributors](https://github.com/sapegin/textlint-rule-terminology/graphs/contributors).
 
 MIT License, see the included [License.md](License.md) file. Also see the [project status](https://github.com/sapegin/textlint-rule-terminology/discussions/65).
-

--- a/index.js
+++ b/index.js
@@ -139,7 +139,7 @@ function getExactMatchRegExp(pattern) {
 		// 2. Exact match of the pattern
 		// 3. Space, punctuation + space, punctuation + punctuation, or punctuation at the end of the string, end of the string
 		`(?<=^|[^-\\w])\\b${pattern}\\b(?= |${punctuation} |${punctuation}${punctuation}|${punctuation}$|$)`,
-		'ig'
+		'igm'
 	);
 }
 

--- a/test.js
+++ b/test.js
@@ -274,6 +274,17 @@ tester.run('textlint-rule-terminology', rule, {
 	],
 	invalid: [
 		{
+			// https://github.com/sapegin/textlint-rule-terminology/discussions/71
+			text: `A Github\n`,
+			output: `A GitHub\n`,
+			errors: [
+				{
+					message:
+						'Incorrect usage of the term: “Github”, use “GitHub” instead',
+				},
+			],
+		},
+		{
 			// One word
 			text: 'My Javascript is good too',
 			output: 'My JavaScript is good too',


### PR DESCRIPTION
- Fixes #71
- Adds a test case that fails without the fix in this PR, but passes otherwise.
- **TL;DR** **Textlint string nodes can contain multiple lines** (i.e., `\n` characters), as you can see from this [textlint AST explorer snippet](https://textlint.github.io/astexplorer/#/snippet/woXCqHBhcnNlcklEwrh0ZXh0bGludDptxINrZG93bi10by1hc3TCqMSFdHTEkGdzwoHEisSMxI7EkMSSxJRyxJbEmMSaxJzEnsSgw4DCqHbEhnNpb27EqMSqxI3Ej8SRxJPElcSXxJnEm8SdxJ90wqYxMy7FjjPCqGZpbGVuYW1lwrBzb3VyY2UudW5kZcWTbmVkwqRjb8WlwrxTb8WZIMSLxI0KQSBHaXRodWIKTW9yZcWzxKs}). Hence the regex match in `getExactMatchRegExp()` should use the `m` modifier, it would seem.

/cc @svrnm @cartermp